### PR TITLE
Fix PySide6 QAction import

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QSettings, Qt
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
-    QAction,
     QApplication,
     QLabel,
     QListWidget,


### PR DESCRIPTION
## Summary
- fix import error for QAction by sourcing it from `PySide6.QtGui`

## Testing
- `pytest -q`
- `QT_QPA_PLATFORM=offscreen python -m src.app` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689c8f0296f48332b393653130df8c8a