### PR TITLE
feat: add master password encryption and dialog

### DIFF
--- a/src/core/crypto.py
+++ b/src/core/crypto.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import sqlite3
+from typing import Optional
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+from .storage import get_connection
+
+
+class CryptoManager:
+    """Manage encryption of secrets using a master password.
+
+    The master password is not stored. Instead a key is derived from it using
+    PBKDF2 and a random salt. The salt, key version and verifier hash are kept
+    in the ``settings`` table. Secrets are stored encrypted in the ``secrets``
+    table and re-encrypted when the master password changes.
+    """
+
+    def __init__(self, conn: Optional[sqlite3.Connection] = None) -> None:
+        self.conn = conn or get_connection()
+        self._fernet: Optional[Fernet] = None
+        self.salt = self._get_setting("crypto_salt")
+        self.version = int(self._get_setting("crypto_key_version") or 0)
+        self.verifier = self._get_setting("crypto_verifier")
+
+    # ------------------------------------------------------------------
+    # Settings helpers
+    # ------------------------------------------------------------------
+    def _get_setting(self, key: str) -> Optional[str]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT value FROM settings WHERE key=?", (key,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+    def _set_setting(self, key: str, value: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    # Key derivation
+    # ------------------------------------------------------------------
+    def derive_key(self, password: str, salt: bytes) -> bytes:
+        """Derive a Fernet key from the password and salt."""
+
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=390_000,
+        )
+        return base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+
+    def is_configured(self) -> bool:
+        """Return ``True`` if a master password has been configured."""
+
+        return self.salt is not None and self.verifier is not None
+
+    # ------------------------------------------------------------------
+    # Master password management
+    # ------------------------------------------------------------------
+    def verify_master_password(self, password: str) -> bool:
+        """Verify the master password, initialising it if missing."""
+
+        if not self.is_configured():
+            self.set_master_password(password)
+            return True
+
+        salt = base64.b64decode(self.salt)
+        key = self.derive_key(password, salt)
+        digest = hashlib.sha256(key).hexdigest()
+        if digest != self.verifier:
+            return False
+        self._fernet = Fernet(key)
+        return True
+
+    def set_master_password(self, password: str) -> None:
+        """Set a new master password and store related metadata."""
+
+        salt = os.urandom(16)
+        key = self.derive_key(password, salt)
+        self._fernet = Fernet(key)
+        self.salt = base64.b64encode(salt).decode("utf-8")
+        self.verifier = hashlib.sha256(key).hexdigest()
+        self.version += 1
+        self._set_setting("crypto_salt", self.salt)
+        self._set_setting("crypto_verifier", self.verifier)
+        self._set_setting("crypto_key_version", str(self.version))
+
+    def rotate_master_password(self, old_password: str, new_password: str) -> bool:
+        """Change master password and re-encrypt all stored secrets."""
+
+        if not self.verify_master_password(old_password):
+            return False
+
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, value FROM secrets")
+        secrets = [(row[0], self.decrypt(row[1])) for row in cur.fetchall()]
+
+        self.set_master_password(new_password)
+
+        for secret_id, plaintext in secrets:
+            cur.execute(
+                "UPDATE secrets SET value=? WHERE id=?",
+                (self.encrypt(plaintext), secret_id),
+            )
+        self.conn.commit()
+        return True
+
+    # ------------------------------------------------------------------
+    # Encryption helpers
+    # ------------------------------------------------------------------
+    def encrypt(self, data: bytes) -> bytes:
+        """Encrypt data using the current master key."""
+
+        if self._fernet is None:
+            raise RuntimeError("Master password not verified")
+        return self._fernet.encrypt(data)
+
+    def decrypt(self, token: bytes) -> bytes:
+        """Decrypt data using the current master key."""
+
+        if self._fernet is None:
+            raise RuntimeError("Master password not verified")
+        return self._fernet.decrypt(token)
+
+    # ------------------------------------------------------------------
+    # Secret storage convenience methods
+    # ------------------------------------------------------------------
+    def set_secret(self, key: str, value: str) -> None:
+        token = self.encrypt(value.encode("utf-8"))
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT OR REPLACE INTO secrets (key, value) VALUES (?, ?)",
+            (key, token),
+        )
+        self.conn.commit()
+
+    def get_secret(self, key: str) -> Optional[str]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT value FROM secrets WHERE key=?", (key,))
+        row = cur.fetchone()
+        if not row:
+            return None
+        return self.decrypt(row[0]).decode("utf-8")

--- a/src/ui/dialog_master_key.py
+++ b/src/ui/dialog_master_key.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import time
+
+from PySide6.QtCore import QTimer
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QVBoxLayout,
+)
+
+from core.crypto import CryptoManager
+
+
+class MasterKeyDialog(QDialog):
+    """Dialog for entering or setting the master password.
+
+    Users have three attempts to enter the correct password. After the third
+    failed attempt the dialog locks for five minutes.
+    """
+
+    def __init__(self, crypto: CryptoManager, parent=None) -> None:
+        super().__init__(parent)
+        self.crypto = crypto
+        self.setWindowTitle("Мастер-пароль")
+        self.attempts = 0
+        self.lock_until: float | None = None
+
+        self.label = QLabel()
+        self.password_edit = QLineEdit()
+        self.password_edit.setEchoMode(QLineEdit.Password)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.label)
+        layout.addWidget(self.password_edit)
+
+        self.confirm_edit: QLineEdit | None = None
+        if not self.crypto.is_configured():
+            self.label.setText("Задайте мастер-пароль")
+            self.confirm_edit = QLineEdit()
+            self.confirm_edit.setEchoMode(QLineEdit.Password)
+            self.confirm_edit.setPlaceholderText("Повторите пароль")
+            layout.addWidget(self.confirm_edit)
+        else:
+            self.label.setText("Введите мастер-пароль")
+
+        self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.buttons.accepted.connect(self._handle_accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addWidget(self.buttons)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _handle_accept(self) -> None:
+        if self.lock_until and time.time() < self.lock_until:
+            QMessageBox.warning(self, "Блокировка", "Повторите попытку позже.")
+            return
+
+        password = self.password_edit.text()
+        if not self.crypto.is_configured():
+            assert self.confirm_edit is not None  # for type checkers
+            if not password or password != self.confirm_edit.text():
+                QMessageBox.warning(self, "Ошибка", "Пароли не совпадают.")
+                return
+            self.crypto.set_master_password(password)
+            self.accept()
+            return
+
+        if not self.crypto.verify_master_password(password):
+            self.attempts += 1
+            QMessageBox.warning(self, "Ошибка", "Неверный пароль.")
+            if self.attempts >= 3:
+                self.lock_until = time.time() + 300
+                self.password_edit.setEnabled(False)
+                QTimer.singleShot(300_000, self._unlock)
+            return
+
+        self.accept()
+
+    def _unlock(self) -> None:
+        self.attempts = 0
+        self.lock_until = None
+        self.password_edit.setEnabled(True)


### PR DESCRIPTION
## Summary
- implement `CryptoManager` with PBKDF2-derived Fernet key, encrypted secret storage and key rotation
- add master password dialog with three attempts and five-minute lockout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9216d3b483328131bdc7a26630db