### PR TITLE
Add environment verification module and UI widget

### DIFF
--- a/src/modules/envcheck/__init__.py
+++ b/src/modules/envcheck/__init__.py
@@ -1,0 +1,25 @@
+"""Environment checking utilities and widget."""
+
+from .checks import (
+    CheckResult,
+    CheckStatus,
+    check_directory_writable,
+    check_odbc_driver,
+    check_python_version,
+    run_checks,
+)
+
+try:  # pragma: no cover - optional GUI dependency
+    from .widget import EnvCheckWidget
+except Exception:  # noqa: BLE001
+    EnvCheckWidget = None  # type: ignore[assignment]
+
+__all__ = [
+    "CheckResult",
+    "CheckStatus",
+    "check_directory_writable",
+    "check_odbc_driver",
+    "check_python_version",
+    "run_checks",
+    "EnvCheckWidget",
+]

--- a/src/modules/envcheck/checks.py
+++ b/src/modules/envcheck/checks.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Iterable
+
+
+class CheckStatus(Enum):
+    """Possible result statuses for environment checks."""
+
+    OK = "ok"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(slots=True)
+class CheckResult:
+    """Represents a single environment check outcome."""
+
+    name: str
+    status: CheckStatus
+    message: str
+
+
+def _run_odbcinst(args: Iterable[str]) -> subprocess.CompletedProcess[str]:
+    """Run `odbcinst` with given arguments."""
+
+    return subprocess.run(
+        ["odbcinst", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def check_odbc_driver() -> CheckResult:
+    """Verify that MS ODBC Driver 17 or 18 for SQL Server is installed."""
+
+    name = "MS ODBC драйвер"
+    try:
+        proc = _run_odbcinst(["-q", "-d"])
+    except FileNotFoundError:
+        return CheckResult(name, CheckStatus.ERROR, "Команда odbcinst не найдена")
+    except subprocess.CalledProcessError:
+        return CheckResult(name, CheckStatus.ERROR, "Не удалось выполнить проверку драйвера")
+
+    drivers = proc.stdout.lower()
+    if "odbc driver 18 for sql server" in drivers or "odbc driver 17 for sql server" in drivers:
+        return CheckResult(name, CheckStatus.OK, "Драйвер найден")
+    return CheckResult(name, CheckStatus.ERROR, "Драйвер MS ODBC 17/18 не найден")
+
+
+def check_directory_writable(path: Path) -> CheckResult:
+    """Check that directory exists and is writable."""
+
+    name = f"Права на запись: {path}"
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        test_file = path / ".write_test"
+        with open(test_file, "w", encoding="utf-8") as fh:
+            fh.write("test")
+        test_file.unlink(missing_ok=True)
+        return CheckResult(name, CheckStatus.OK, "Доступно")
+    except Exception:  # noqa: BLE001
+        return CheckResult(name, CheckStatus.ERROR, "Нет прав на запись")
+
+
+def check_python_version(min_version: tuple[int, int] = (3, 10)) -> CheckResult:
+    """Check that current Python version is supported."""
+
+    name = "Версия Python"
+    current = sys.version_info
+    version_str = f"{current.major}.{current.minor}.{current.micro}"
+    if (current.major, current.minor) >= min_version:
+        return CheckResult(name, CheckStatus.OK, version_str)
+    required = f">= {min_version[0]}.{min_version[1]}"
+    return CheckResult(name, CheckStatus.ERROR, f"{version_str} (требуется {required})")
+
+
+def run_checks() -> list[CheckResult]:
+    """Run all environment checks and return their results."""
+
+    base_dir = Path(__file__).resolve().parents[3]
+    checks = [
+        check_odbc_driver(),
+        check_directory_writable(base_dir / "data"),
+        check_directory_writable(base_dir / "logs"),
+        check_python_version(),
+    ]
+    return checks

--- a/src/modules/envcheck/widget.py
+++ b/src/modules/envcheck/widget.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .checks import CheckResult, CheckStatus, run_checks
+
+
+class EnvCheckWidget(QWidget):
+    """Widget displaying environment check results."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._create_ui()
+        self.run_checks()
+
+    # ------------------------------------------------------------------
+    # UI creation
+    # ------------------------------------------------------------------
+    def _create_ui(self) -> None:
+        self.layout = QVBoxLayout(self)
+        self.status_labels: Dict[str, QLabel] = {}
+
+        items = {
+            "odbc": "ODBC драйвер",
+            "data": "Каталог data",
+            "logs": "Каталог logs",
+            "python": "Версия Python",
+        }
+
+        for key, title in items.items():
+            label = QLabel(f"{title}: ...")
+            self.layout.addWidget(label)
+            self.status_labels[key] = label
+
+        btn_layout = QHBoxLayout()
+        self.repeat_btn = QPushButton("Повторить проверку")
+        self.continue_btn = QPushButton("Продолжить")
+        self.continue_btn.setEnabled(False)
+        btn_layout.addWidget(self.repeat_btn)
+        btn_layout.addWidget(self.continue_btn)
+        self.layout.addLayout(btn_layout)
+
+        self.repeat_btn.clicked.connect(self.run_checks)
+
+    # ------------------------------------------------------------------
+    # Checks
+    # ------------------------------------------------------------------
+    def run_checks(self) -> None:
+        """Execute all checks and update UI."""
+
+        results = run_checks()
+        mapping = {
+            "odbc": results[0],
+            "data": results[1],
+            "logs": results[2],
+            "python": results[3],
+        }
+
+        all_ok = True
+        for key, result in mapping.items():
+            self._apply_result(key, result)
+            if result.status is not CheckStatus.OK:
+                all_ok = False
+
+        self.continue_btn.setEnabled(all_ok)
+
+    def _apply_result(self, key: str, result: CheckResult) -> None:
+        label = self.status_labels[key]
+        label.setText(f"{label.text().split(':')[0]}: {result.message}")
+        color = {
+            CheckStatus.OK: "green",
+            CheckStatus.WARNING: "orange",
+            CheckStatus.ERROR: "red",
+        }[result.status]
+        label.setStyleSheet(f"color: {color}")

--- a/src/tests/test_envcheck.py
+++ b/src/tests/test_envcheck.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from modules.envcheck import (
+    CheckStatus,
+    check_directory_writable,
+    check_odbc_driver,
+    check_python_version,
+)
+
+
+class DummyProcess:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+def test_check_odbc_driver_found(monkeypatch):
+    def fake_run(args):
+        return DummyProcess("ODBC Driver 17 for SQL Server")
+
+    monkeypatch.setattr("modules.envcheck.checks._run_odbcinst", fake_run)
+    result = check_odbc_driver()
+    assert result.status is CheckStatus.OK
+
+
+def test_check_odbc_driver_missing(monkeypatch):
+    def fake_run(args):
+        return DummyProcess("Some Other Driver")
+
+    monkeypatch.setattr("modules.envcheck.checks._run_odbcinst", fake_run)
+    result = check_odbc_driver()
+    assert result.status is CheckStatus.ERROR
+    assert "не найден" in result.message.lower()
+
+
+def test_check_directory_writable(tmp_path):
+    result = check_directory_writable(tmp_path)
+    assert result.status is CheckStatus.OK
+
+
+def test_check_python_version(monkeypatch):
+    class V:
+        major, minor, micro = 3, 9, 0
+
+    monkeypatch.setattr(sys, "version_info", V())
+    result = check_python_version()
+    assert result.status is CheckStatus.ERROR


### PR DESCRIPTION
## Summary
- add envcheck module with ODBC driver, directory write access and Python version checks
- provide PySide6 widget showing statuses with retry and continue buttons
- cover envcheck checks with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c933d17088332baeb7efc9bba1cfc