### PR TITLE
Fix core module imports for direct execution

### DIFF
--- a/src/modules/datasource/connection_manager.py
+++ b/src/modules/datasource/connection_manager.py
@@ -6,8 +6,18 @@ from typing import List, Optional, Tuple
 import pyodbc
 from pydantic import BaseModel, field_validator
 
-from core.crypto import CryptoManager
-from core.storage import get_connection
+# Import ``core`` in a way that works whether the project is installed or run
+# directly with ``python -m src.app``.
+try:
+    # When tests or an installed package import ``modules.datasource``, ``core``
+    # is available as a top-level package.
+    from core.crypto import CryptoManager
+    from core.storage import get_connection
+except ImportError:  # pragma: no cover - fallback for running from source
+    # When executing directly from the source tree, ``modules`` is imported as
+    # ``src.modules`` and we need a relative import to reach ``src.core``.
+    from ...core.crypto import CryptoManager
+    from ...core.storage import get_connection
 
 
 class ConnectionProfile(BaseModel):

--- a/src/ui/dialog_master_key.py
+++ b/src/ui/dialog_master_key.py
@@ -12,7 +12,9 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from core.crypto import CryptoManager
+# ``ui`` is a sibling of ``core`` inside ``src``; use a relative import so the
+# application can be executed without adjusting ``PYTHONPATH``.
+from ..core.crypto import CryptoManager
 
 
 class MasterKeyDialog(QDialog):


### PR DESCRIPTION
## Summary
- Ensure datasource connection manager imports core package whether running from source or installed.
- Use relative import for master key dialog to avoid PYTHONPATH adjustments.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca73f8b588332a8078ec10a125019