### PR TITLE
Add SQL guard to block unsafe database operations

### DIFF
--- a/src/modules/security/__init__.py
+++ b/src/modules/security/__init__.py
@@ -1,0 +1,5 @@
+"""Security related utilities."""
+
+from .sql_guard import SQLSecurityError, validate_sql
+
+__all__ = ["SQLSecurityError", "validate_sql"]

--- a/src/modules/security/sql_guard.py
+++ b/src/modules/security/sql_guard.py
@@ -1,0 +1,64 @@
+"""Simple SQL validator enforcing read-only (SELECT) policy.
+
+The validator checks that the query contains only a limited set of characters
+and does not include any blacklisted SQL keywords or comment tokens.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+__all__ = ["SQLSecurityError", "validate_sql"]
+
+
+class SQLSecurityError(ValueError):
+    """Raised when a SQL statement violates the security policy."""
+
+
+# Disallowed keywords that could modify database state or execute code
+BLACKLIST_KEYWORDS: set[str] = {
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "MERGE",
+    "EXEC",
+    "CREATE",
+    "ALTER",
+    "DROP",
+}
+
+# Allowed characters (case insensitive). The pattern intentionally permits
+# common SQL syntax while excluding dangerous symbols like ';'.
+_ALLOWED_CHARS_RE = re.compile(r"^[A-Za-z0-9_\s,.*=<>!+\-/()%@'\"]*$")
+
+
+def _tokenize(query: str) -> Iterable[str]:
+    """Return alphanumeric tokens from *query* in upper-case."""
+
+    return re.findall(r"[A-Za-z_]+", query.upper())
+
+
+def validate_sql(query: str) -> None:
+    """Validate *query* to ensure it is safe to execute.
+
+    The function raises :class:`SQLSecurityError` if the query contains
+    disallowed characters, comments, statement separators or any of the
+    blacklisted keywords defined in :data:`BLACKLIST_KEYWORDS`.
+    """
+
+    if not isinstance(query, str):
+        raise SQLSecurityError("SQL query must be a string")
+
+    if ";" in query:
+        raise SQLSecurityError("Символ ';' запрещён")
+    if "--" in query or "/*" in query or "*/" in query:
+        raise SQLSecurityError("Комментарии запрещены")
+
+    if not _ALLOWED_CHARS_RE.fullmatch(query):
+        raise SQLSecurityError("Обнаружены недопустимые символы")
+
+    tokens = _tokenize(query)
+    for token in tokens:
+        if token in BLACKLIST_KEYWORDS:
+            raise SQLSecurityError(f"Токен '{token}' запрещён")

--- a/src/tests/test_sql_guard.py
+++ b/src/tests/test_sql_guard.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from modules.security.sql_guard import SQLSecurityError, validate_sql
+
+
+def test_valid_select_passes():
+    validate_sql("SELECT * FROM users WHERE id = 1")
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "INSERT INTO users VALUES (1)",
+        "UPDATE users SET name='x'",
+        "DELETE FROM users",
+        "MERGE INTO users AS t",
+        "EXEC sp_who",
+        "CREATE TABLE t(id INT)",
+        "ALTER TABLE t ADD c INT",
+        "DROP TABLE t",
+        "SELECT * FROM users; DROP TABLE users",
+        "SELECT * FROM users -- comment",
+        "SELECT /* comment */ * FROM users",
+    ],
+)
+def test_invalid_queries(query: str):
+    with pytest.raises(SQLSecurityError):
+        validate_sql(query)


### PR DESCRIPTION
## Summary
- add SQL validator to detect disallowed tokens and symbols
- add tests covering valid and invalid queries

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd48cc02c8332bab79b0da8ce48d6