### PR TITLE
feat: implement module API contract and base class

### DIFF
--- a/src/core/module_api.py
+++ b/src/core/module_api.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List
+
+
+class Module(ABC):
+    """Контракт для модулей приложения."""
+
+    id: str
+    title: str
+    icon: str
+
+    @abstractmethod
+    def mount(self, ui: Any, app: Any, bus: Any) -> None:
+        """Инициализирует модуль и добавляет его в интерфейс."""
+
+    @abstractmethod
+    def unmount(self) -> None:
+        """Удаляет модуль из интерфейса."""
+
+    @abstractmethod
+    def get_sidebar_items(self) -> List[Any]:
+        """Возвращает элементы боковой панели."""
+
+    @abstractmethod
+    def get_properties_widget(self, ui: Any) -> Any:
+        """Создаёт виджет свойств."""
+
+    @abstractmethod
+    def get_preview_widget(self, ui: Any) -> Any:
+        """Создаёт виджет предпросмотра."""
+
+
+class BaseModule(Module):
+    """Базовый модуль с пустыми реализациями по умолчанию."""
+
+    id = ""
+    title = ""
+    icon = ""
+
+    def mount(self, ui: Any, app: Any, bus: Any) -> None:
+        pass
+
+    def unmount(self) -> None:
+        pass
+
+    def get_sidebar_items(self) -> List[Any]:
+        return []
+
+    def get_properties_widget(self, ui: Any) -> Any:
+        return None
+
+    def get_preview_widget(self, ui: Any) -> Any:
+        return None

--- a/src/tests/test_module_api.py
+++ b/src/tests/test_module_api.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+
+from core.module_api import BaseModule
+
+
+class DummyModule(BaseModule):
+    id = "dummy"
+    title = "Dummy"
+    icon = ""
+
+
+def test_mount_unmount_no_errors():
+    module = DummyModule()
+    module.mount(None, None, None)
+    module.unmount()
+
+
+def test_default_widget_methods():
+    module = DummyModule()
+    assert module.get_sidebar_items() == []
+    assert module.get_properties_widget(None) is None
+    assert module.get_preview_widget(None) is None


### PR DESCRIPTION
## Summary
- define abstract `Module` interface with lifecycle and UI hooks
- add `BaseModule` providing default empty implementations
- test module API to ensure modules mount and provide default widgets without errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cdd471a508332854a24b27572e223