### PR TITLE
Implement module registry with autodiscovery

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -11,6 +11,7 @@ from ..core.app import AppContext
 from ..core.config import load_config
 from ..core.events import EventBus
 from ..core.logger import setup_logging
+from ..core.registry import autodiscover_modules
 from ..ui.main_window import MainWindow
 
 
@@ -24,6 +25,7 @@ def main() -> None:
     context.set("event_bus", event_bus)
 
     config = load_config()
+    autodiscover_modules()
     logging.info("Приложение запущено")
 
     app = QApplication(sys.argv)

--- a/src/core/registry.py
+++ b/src/core/registry.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .module_api import Module
+
+
+class ModuleRegistry:
+    """Реестр модулей приложения."""
+
+    def __init__(self) -> None:
+        self._modules: Dict[str, Module] = {}
+
+    def register(self, module: Module) -> None:
+        """Регистрирует модуль."""
+        if module.id in self._modules:
+            logging.warning("Модуль %s уже зарегистрирован", module.id)
+            return
+        self._modules[module.id] = module
+
+    def get(self, module_id: str) -> Optional[Module]:
+        """Возвращает модуль по идентификатору."""
+        return self._modules.get(module_id)
+
+    def all(self) -> List[Module]:
+        """Возвращает все зарегистрированные модули."""
+        return list(self._modules.values())
+
+
+registry = ModuleRegistry()
+
+
+def autodiscover_modules(base_path: Optional[Path] = None) -> List[Module]:
+    """Импортирует модули из каталога ``modules`` и регистрирует их."""
+    modules_dir = base_path or Path(__file__).resolve().parent.parent / "modules"
+
+    if not modules_dir.exists():
+        logging.info("Каталог модулей %s не найден", modules_dir)
+        return []
+
+    for item in modules_dir.iterdir():
+        module_file = item / "module.py"
+        if module_file.exists():
+            module_name = f"modules.{item.name}.module"
+            try:
+                importlib.import_module(module_name)
+            except Exception:  # pragma: no cover - логирование исключений
+                logging.exception("Ошибка загрузки модуля %s", module_name)
+
+    modules = registry.all()
+    if modules:
+        logging.info("Обнаруженные модули: %s", ", ".join(m.id for m in modules))
+    else:
+        logging.info("Модули не обнаружены")
+    return modules

--- a/src/tests/test_registry.py
+++ b/src/tests/test_registry.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from core.module_api import BaseModule
+from core.registry import autodiscover_modules, registry
+
+
+class DummyModule(BaseModule):
+    id = "dummy"
+    title = "Dummy"
+
+
+def test_register_and_get():
+    registry._modules.clear()
+    module = DummyModule()
+    registry.register(module)
+    assert registry.get("dummy") is module
+    assert module in registry.all()
+
+
+def test_autodiscover(tmp_path):
+    registry._modules.clear()
+    modules_dir = Path("src/modules/testmod")
+    modules_dir.mkdir(parents=True, exist_ok=True)
+    (modules_dir / "__init__.py").write_text("")
+    (modules_dir / "module.py").write_text(
+        "from core.module_api import BaseModule\n"
+        "from core.registry import registry\n"
+        "class TestModule(BaseModule):\n"
+        "    id='test'\n"
+        "module=TestModule()\n"
+        "registry.register(module)\n"
+    )
+
+    try:
+        autodiscover_modules()
+        assert registry.get("test") is not None
+    finally:
+        for file in modules_dir.glob("**/*"):
+            if file.is_file():
+                file.unlink()
+        for directory in sorted(modules_dir.glob("**"), reverse=True):
+            if directory.is_dir():
+                directory.rmdir()
+        registry._modules.clear()


### PR DESCRIPTION
## Summary
- add ModuleRegistry and autodiscover_modules for dynamic module loading
- call autodiscover_modules on application start and log discovered modules
- test module registry registration and autodiscovery

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cde4587cc8332a5dc32d04778f1dc